### PR TITLE
Remove outdated c_buffer template references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,15 @@
 EVKey - Vietnamese Keyboard
 
 Homepage : https://evkeyvn.com
+
+## Buffer Type Aliases
+
+EVKey defines convenient aliases for common buffer types using `std::vector`:
+
+- `c_byte_buffer` – `std::vector<unsigned char>`
+- `c_int_buffer` – `std::vector<int>`
+- `c_char_buffer` – `std::vector<char>`
+- `c_string_buffer` – `std::vector<std::string>`
+- `c_wstring_buffer` – `std::vector<std::wstring>`
+
+The legacy `c_buffer` template is no longer used.

--- a/evkau/evkau/c_buffer.h
+++ b/evkau/evkau/c_buffer.h
@@ -3,7 +3,9 @@
 #include "_globaldef.h"
 #include <vector>
 
-//typedef c_buffer<byte> c_byte_buffer;
+// Buffer type aliases implemented with std::vector. The former c_buffer
+// template has been removed in favour of direct std::vector usage.
+typedef std::vector<unsigned char> c_byte_buffer;
 typedef std::vector<int> c_int_buffer;
 typedef std::vector<char> c_char_buffer;
 typedef std::vector<std::string> c_string_buffer;


### PR DESCRIPTION
## Summary
- replace obsolete c_buffer comment with direct std::vector buffer aliases
- document buffer type aliases and removal of c_buffer template

## Testing
- `g++ -std=c++17 -fsyntax-only evkau/evkau/c_buffer.h` *(fails: ‘HWND’ does not name a type)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a02055c630832e98f8c50cf2f25614